### PR TITLE
NullReferenceException when using InjectionFactory to register type

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.Runners" version="2.6.2" />
+</packages>

--- a/Hazware.Unity.TypeTracking.sln
+++ b/Hazware.Unity.TypeTracking.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{4E8DB9
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
+		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject
 Global

--- a/default.ps1
+++ b/default.ps1
@@ -21,7 +21,7 @@ properties {
   $v4_net_version = (ls "$env:windir\Microsoft.NET\Framework\v4.0*").Name
   $project_base = "$src_dir\$sln_base"
   $test_base = "tests\$sln_base.Tests"
-  $nunit_dir = "..\..\..\packages\NUnit.2.5.10.11092\tools"
+  $nunit_dir = "..\..\..\packages\NUnit.Runners.2.6.2\tools"
 
   $project_dlls = @( "Hazware.Unity.TypeTracking.dll" );
   $test_dlls = @("Hazware.Unity.TypeTracking.Tests.dll" );

--- a/src/Hazware.Unity.TypeTracking-NET35/TypeTrackingExtension.cs
+++ b/src/Hazware.Unity.TypeTracking-NET35/TypeTrackingExtension.cs
@@ -51,9 +51,10 @@ namespace Hazware.Unity.TypeTracking
     {
       HashSet<string> names;
       string name = string.IsNullOrEmpty(e.Name) ? string.Empty : e.Name;
-      if (!_registeredTypes.TryGetValue(e.TypeFrom, out names))
+	  Type type = e.TypeFrom ?? e.TypeTo;
+      if (!_registeredTypes.TryGetValue(type, out names))
       { //  not found, so add it
-        _registeredTypes.Add(e.TypeFrom, new HashSet<string>(new string[] { name }));
+        _registeredTypes.Add(type, new HashSet<string>(new string[] { name }));
       }
       else
       { //  already added type, so add name

--- a/tests/Hazware.Unity.TypeTracking.Tests-NET35/TypeTrackingTestFixture.cs
+++ b/tests/Hazware.Unity.TypeTracking.Tests-NET35/TypeTrackingTestFixture.cs
@@ -30,8 +30,18 @@ namespace Hazware.Unity.TypeTracking.Tests
     }
     #endregion
 
-    #region TryResolveUnknown
-    [Test]
+	#region Register FactoryInjection
+	[Test]
+	public void RegisterFactoryInjection()
+	{
+		Assert.DoesNotThrow(new TestDelegate(() => {
+			_container.RegisterType<ITest>(new InjectionFactory(c => new TestClass()));
+		}));
+	}
+	#endregion
+
+	#region TryResolveUnknown
+	[Test]
     public void TryResolveOfUnknownType()
     {
       ITest obj = _container.Configure<TypeTrackingExtension>().TryResolve<ITest>();


### PR DESCRIPTION
When using InjectionFactory to register a type the FromType property for the RegisterEventArgs will be null. This causes a NullReferenceException to be thrown. I've added a test to demonstrate the issue. If I can figure out the problem and get all tests to pass I'll submit a pull request for that as well. But I just thought you'd like to have the test anyway.
